### PR TITLE
Filter keys w/ objects as values

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,11 @@ function isObjectLike (x) { return x !== null && typeof x === 'object' }
 function filter (obj, blacklist, accum) {
   if (isObjectLike(obj)) {
     for (var prop in obj) {
-      if (isObjectLike(obj[prop])) {
+      if (blacklist.indexOf(prop) !== -1) {
+        accum[prop] = FILTERED_VALUE
+      } else if (isObjectLike(obj[prop])) {
         accum[prop] = {}
         filter(obj[prop], blacklist, accum[prop])
-      } else if (blacklist.indexOf(prop) !== -1) {
-        accum[prop] = FILTERED_VALUE
       } else {
         accum[prop] = obj[prop]
       }

--- a/test.js
+++ b/test.js
@@ -81,3 +81,15 @@ assert.deepEqual(sanitizeObject({
   uhOh: null,
   arrayOfNull: [null, 1]
 }, 'Replaces the values of sensitive keys')
+
+assert.deepEqual(sanitizeObject({
+  uhOh: null,
+  arrayOfNull: [null, 1],
+  privateData: {
+    foo: 'bar'
+  }
+}, ['privateData']), {
+  uhOh: null,
+  arrayOfNull: [null, 1],
+  privateData: '[FILTERED]'
+}, 'Replaces the values of sensitive keys that point to objects')


### PR DESCRIPTION
Keys that were in the blacklist were skipped over if they had an object as their value. Its plausible that an entire object should be filtered if all of its keys are sensitive.
